### PR TITLE
Bugfix failure after making several words in row as leaned

### DIFF
--- a/packages/front/src/pages/games/game/GamePage.tsx
+++ b/packages/front/src/pages/games/game/GamePage.tsx
@@ -142,7 +142,8 @@ const GamePage = () => {
     }
   };
 
-  const handleNext = (isLearned?: boolean) => {
+  const handleNext = (val?: boolean) => {
+    const isLearned = val ?? false;
     dispatch({ type: GameAction.NEXT, payload: { isLearned } });
   };
 

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -23,7 +23,7 @@ export const Checkbox = ({
   iconId = 'asc',
   onChange
 }: CheckboxProps) => {
-  const [isChecked, setIsChecked] = useState(initialValue);
+  const [isChecked, setIsChecked] = useState(initialValue || false);
 
   const renderLabel = () => {
     if (variant === 'isOffensive') {

--- a/packages/ui/src/components/Game/Game.tsx
+++ b/packages/ui/src/components/Game/Game.tsx
@@ -87,11 +87,8 @@ export const Game = ({
   // Clean the state once the question is answered
   const handleNext = () => {
     setValue('');
-    if (!memoryRefresherMode && isLearned) {
-      onNext(isLearned);
-      setIsLearned(false);
-    }
-    onNext();
+    onNext(isLearned);
+    setIsLearned(false);
   };
   const renderQuestion = () => {
     if (type === GameType.Audio) {


### PR DESCRIPTION
- [ ]  Bug in dev env: when marking the word as learned, page goes blank. Also investigate why error boundary is not shown.
- [ ] Additionally: fix React warning about Checkbox component
```javascript
const [isChecked, setIsChecked] = useState(initialValue || false);
```
