### PR TITLE
bugfix: blank page after reloading on subroutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ open `localhost:8080` in your browser
 
 ## Production and deploy
 
-run `docker compose -f docker-compose-prod.yml up -d` 
+run `docker compose -f docker-compose-prod.yml up -d`
 to start the server on port `4000` and the frontend on `8080`in detached mode.
 
 run `docker compose down` to stop containers.
 
 run `yarn build:front` to build frontend. It generates files in `packages/front/public`.
+
+## Pre-production deploy
+
+run `docker compose -f docker-compose-preprod.yml up -d`
+to start front on port `8080`. For this case, the server and DB should be run locally.

--- a/docker-compose-preprod.yml
+++ b/docker-compose-preprod.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  lp-front:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile-front-prod
+    ports:
+      - '8080:80'
+    env_file:
+      - ./packages/front/.env
+    stdin_open: true
+    tty: true

--- a/packages/front/build-utils/webpack.production.js
+++ b/packages/front/build-utils/webpack.production.js
@@ -8,6 +8,7 @@ const path = require('path');
 module.exports = {
   mode: 'production',
   output: {
+    publicPath: '/',
     path: path.resolve(__dirname, '../public')
   },
   module: {

--- a/packages/front/src/pages/error/ErrorPage.tsx
+++ b/packages/front/src/pages/error/ErrorPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { useRouteError, useNavigate } from 'react-router-dom';
+import { useRouteError, useNavigate, Outlet } from 'react-router-dom';
 import { ErrorDisplay } from '@lp/ui';
 import { PageLayout } from '../../components/PageLayout/PageLayout';
 
@@ -21,6 +21,7 @@ const ErrorPage = () => {
         buttonText="Reload"
         heading="Something went wrong"
       />
+      <Outlet />
     </PageLayout>
   );
 };

--- a/packages/front/src/pages/words/WordsPage.tsx
+++ b/packages/front/src/pages/words/WordsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext, useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import {
   useWordsLazyQuery,
   Word,
@@ -176,6 +176,7 @@ const WordsPage = () => {
       )}
       {loading && <Spinner />}
       {renderWords()}
+      <Outlet />
     </PageLayout>
   );
 };


### PR DESCRIPTION
- [ ]  Bug: when you exit the browser while being on the game page, the next time you get the error and a blank page. It also happens if you open a link like `https://dev.language-power.fun/games/select_def?isReverseOrder=false&sortBy=lastTimePracticed` in a new tab. The same problem occurs on the word page: `https://dev.language-power.fun/words/review/6547605db8d73566c3ebdd2b`; The same problem appears on the word's page

The root of the problem: incorrect `webpack` production configuration:  [stackoverflow](https://stackoverflow.com/questions/34620628/htmlwebpackplugin-injects-relative-path-files-which-breaks-when-loading-non-root)
Add `publickPath` to the `output` property

For the future: create a docker configuration to test the app before deploying.